### PR TITLE
replace uninformative link text in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,15 +14,15 @@ RespiCompass welcomes teams willing to contribute their projections. Detailed in
 
 1. **Create a Metadata File**:
    - Include key information about your team and model.
-   - Detailed instructions can be found [here](https://github.com/european-modelling-hubs/RespiCompass/wiki/Metadata).
+   - read more [detailed instructions to create a metadata file](https://github.com/european-modelling-hubs/RespiCompass/wiki/Metadata).
 
 2. **Develop Your Model**:
    - Develop your model and produce projections. We value diverse model approaches and implementations.
    - Ensure your projections respect the provided scenario assumptions (refer to specific rounds information).
 
 3. **Submit Model Projections**:
-   - Follow the submission format detailed [here](https://github.com/european-modelling-hubs/RespiCompass/wiki/Submission-format).
-   - Submit your projections via a pull request as outlined [here](https://github.com/european-modelling-hubs/RespiCompass/wiki/Submitting-using-GitHub-Website).
+   - Follow the [submission format guidelines](https://github.com/european-modelling-hubs/RespiCompass/wiki/Submission-format).
+   - Submit your projections by following the [instructions to open a pull request](https://github.com/european-modelling-hubs/RespiCompass/wiki/Submitting-using-GitHub-Website).
 
 For any questions, please email us at [European.Modelling.Hub@ecdc.europa.eu](mailto:European.Modelling.Hub@ecdc.europa.eu).
 


### PR DESCRIPTION
👋🏽 Hello! I noticed that the README has several links that say "here", which can be inaccessible for users of screen readers.

The changes I propose will satisfy accessibility according to [WCAG 2.1 Technique H30](https://www.w3.org/WAI/WCAG21/Techniques/html/H30.html)